### PR TITLE
feat: Add Apple Silicon MPS support

### DIFF
--- a/fl_nodes/decode.py
+++ b/fl_nodes/decode.py
@@ -124,3 +124,5 @@ class FL_HeartMuLa_Decode:
             gc.collect()
             if torch.cuda.is_available():
                 torch.cuda.empty_cache()
+            if torch.backends.mps.is_available():
+                torch.mps.empty_cache()

--- a/fl_nodes/sampler.py
+++ b/fl_nodes/sampler.py
@@ -131,6 +131,8 @@ class FL_HeartMuLa_Sampler:
         if torch.cuda.is_available():
             torch.cuda.manual_seed(seed)
             torch.cuda.manual_seed_all(seed)
+        if torch.backends.mps.is_available():
+            torch.mps.manual_seed(seed)
 
         print(f"\n{'='*60}")
         print(f"[FL HeartMuLa] Sampling Audio Tokens")
@@ -258,3 +260,5 @@ class FL_HeartMuLa_Sampler:
             gc.collect()
             if torch.cuda.is_available():
                 torch.cuda.empty_cache()
+            if torch.backends.mps.is_available():
+                torch.mps.empty_cache()

--- a/fl_utils/model_manager.py
+++ b/fl_utils/model_manager.py
@@ -189,12 +189,15 @@ def load_model(
     # Determine device
     if torch.cuda.is_available():
         device = torch.device("cuda")
+    elif torch.backends.mps.is_available():
+        device = torch.device("mps")
     else:
         device = torch.device("cpu")
 
     # Determine dtype
+    # Note: MPS supports float16 but NOT bfloat16
     if precision == "auto":
-        if device.type == "cuda":
+        if device.type in ("cuda", "mps"):
             dtype = torch.float16
         else:
             dtype = torch.float32
@@ -225,18 +228,24 @@ def load_model(
     # Setup quantization config if needed
     bnb_config = None
     if use_4bit:
-        try:
-            from transformers import BitsAndBytesConfig
-            bnb_config = BitsAndBytesConfig(
-                load_in_4bit=True,
-                bnb_4bit_compute_dtype=dtype,
-                bnb_4bit_use_double_quant=True,
-                bnb_4bit_quant_type="nf4",
-            )
-            print("[FL HeartMuLa] Using 4-bit quantization")
-        except ImportError:
-            print("[FL HeartMuLa] WARNING: bitsandbytes not installed, using full precision")
-            bnb_config = None
+        # 4-bit quantization only works on CUDA (bitsandbytes requirement)
+        if device.type != "cuda":
+            print(f"[FL HeartMuLa] WARNING: 4-bit quantization requires CUDA, but device is {device.type}")
+            print("[FL HeartMuLa] Disabling 4-bit quantization, using full precision instead")
+            use_4bit = False
+        else:
+            try:
+                from transformers import BitsAndBytesConfig
+                bnb_config = BitsAndBytesConfig(
+                    load_in_4bit=True,
+                    bnb_4bit_compute_dtype=dtype,
+                    bnb_4bit_use_double_quant=True,
+                    bnb_4bit_quant_type="nf4",
+                )
+                print("[FL HeartMuLa] Using 4-bit quantization")
+            except ImportError:
+                print("[FL HeartMuLa] WARNING: bitsandbytes not installed, using full precision")
+                bnb_config = None
 
     # Load the pipeline
     print(f"[FL HeartMuLa] Loading HeartMuLa-{variant} pipeline...")
@@ -247,6 +256,12 @@ def load_model(
         version=variant,
         bnb_config=bnb_config,
     )
+
+    # Get actual device from loaded model (may differ if quantization forced CPU)
+    actual_device = next(pipeline.model.parameters()).device
+    if actual_device != device:
+        print(f"[FL HeartMuLa] Note: Model loaded on {actual_device} (requested {device})")
+        device = actual_device
 
     # Create model info dict
     model_info = {
@@ -278,6 +293,8 @@ def clear_model_cache():
     gc.collect()
     if torch.cuda.is_available():
         torch.cuda.empty_cache()
+    if torch.backends.mps.is_available():
+        torch.mps.empty_cache()
 
     print("[FL HeartMuLa] Model cache cleared")
 

--- a/heartlib/heartcodec/modeling_heartcodec.py
+++ b/heartlib/heartcodec/modeling_heartcodec.py
@@ -62,11 +62,19 @@ class HeartCodec(PreTrainedModel):
         num_steps=10,
         disable_progress=False,
         guidance_scale=1.25,
-        device="cuda",
+        device=None,
     ):
+        # Auto-detect device if not specified
+        if device is None:
+            if torch.cuda.is_available():
+                device = "cuda"
+            elif torch.backends.mps.is_available():
+                device = "mps"
+            else:
+                device = "cpu"
         codes = codes.unsqueeze(0).to(device)
-        first_latent = torch.randn(codes.shape[0], int(duration * 25), 256).to(
-            device
+        first_latent = torch.randn(
+            codes.shape[0], int(duration * 25), 256, device=device
         )  # B, T, 64
         first_latent_length = 0
         first_latent_codes_length = 0
@@ -123,7 +131,8 @@ class HeartCodec(PreTrainedModel):
                             true_latent.shape[0],
                             len_add_to_latent,
                             true_latent.shape[-1],
-                        ).to(device),
+                            device=device,
+                        ),
                     ],
                     1,
                 )

--- a/heartlib/heartcodec/models/transformer.py
+++ b/heartlib/heartcodec/models/transformer.py
@@ -423,7 +423,7 @@ class PixArtAlphaCombinedFlowEmbeddings(nn.Module):
             -math.log(max_period)
             * torch.arange(start=0, end=half, device=timesteps.device)
             / half
-        ).type(timesteps.type())
+        ).to(dtype=timesteps.dtype)  # Use .to() instead of .type() for MPS compatibility
         args = timesteps[:, None] * freqs[None] * scale
         embedding = torch.cat([torch.cos(args), torch.sin(args)], dim=-1)
         if self.flow_t_size % 2:

--- a/heartlib/heartmula/modeling_heartmula.py
+++ b/heartlib/heartmula/modeling_heartmula.py
@@ -161,7 +161,9 @@ class HeartMuLa(PreTrainedModel):
         except RuntimeError:
             pass
 
-        with device:
+        # Use torch.device() context manager for proper device allocation
+        # The bare `with device:` syntax doesn't work correctly, especially on MPS
+        with torch.device(device):
             self.backbone.setup_caches(max_batch_size, dtype)
             self.decoder.setup_caches(
                 max_batch_size,

--- a/heartlib/pipelines/music_generation.py
+++ b/heartlib/pipelines/music_generation.py
@@ -234,7 +234,9 @@ class HeartMuLaGenPipeline(Pipeline):
         if os.path.exists(
             heartcodec_path := os.path.join(pretrained_path, "HeartCodec-oss")
         ):
-            heartcodec = HeartCodec.from_pretrained(heartcodec_path, device_map=device)
+            # device_map expects string, not torch.device object
+            device_str = str(device) if isinstance(device, torch.device) else device
+            heartcodec = HeartCodec.from_pretrained(heartcodec_path, device_map=device_str)
         else:
             raise FileNotFoundError(
                 f"Expected to find checkpoint for HeartCodec at {heartcodec_path} but not found. Please check your folder {pretrained_path}."


### PR DESCRIPTION
## Summary

This PR enables HeartMuLa to run on Apple Silicon Macs using Metal Performance Shaders (MPS).

Previously, the code only supported CUDA GPUs and fell back to slow CPU inference on Macs. With these changes, Mac users with M1/M2/M3/M4 chips can use their GPU for significantly faster inference.

## Changes

- **Device detection**: Added MPS device detection alongside CUDA
- **KV cache fix**: Fixed context manager usage in `setup_caches()` that didn't work with MPS
- **HeartCodec fix**: Removed hardcoded `device="cuda"` default parameter
- **Type casting fix**: Replaced `.type(tensor.type())` with `.to(dtype=tensor.dtype)` - the former returns invalid strings on MPS
- **Memory management**: Added `torch.mps.empty_cache()` calls for proper cleanup
- **Seed setting**: Added `torch.mps.manual_seed()` for reproducibility
- **4-bit quantization**: Auto-disables on non-CUDA devices with warning (bitsandbytes requires CUDA)
- **Device fallback**: Detects actual model device after loading in case of fallbacks

## Testing

Tested on M-series Mac with:
- PyTorch 2.10.0
- macOS 26.2
- Successfully generates full-length audio (~2.4 it/s sampling, full decode working)

## Test Plan

- [x] Model loads on MPS device
- [x] Sampling completes without device mismatch errors  
- [x] Decoding completes without type errors
- [x] Audio output is correct length and playable